### PR TITLE
Fix FFmpeg crossfade filter syntax for 7.1+ compatibility

### DIFF
--- a/ffmpeg/src/main/java/no/lau/vdvil/snippets/FFmpegFunctions.java
+++ b/ffmpeg/src/main/java/no/lau/vdvil/snippets/FFmpegFunctions.java
@@ -201,7 +201,7 @@ public class FFmpegFunctions {
             String crossfadeCommand = ImprovedFFMpegFunctions.ffmpegLocation + 
                 " -i " + snippets[0] + 
                 " -i " + snippets[1] + 
-                " -filter_complex \"[0:v][1:v]xfade=transition=fade:duration=" + crossfadeDuration + ":offset=" + (getTotalDuration(snippets[0]) - crossfadeDuration) + "[outv]\" " +
+                " -filter_complex [0:v][1:v]xfade=transition=fade:duration=" + crossfadeDuration + ":offset=" + (getTotalDuration(snippets[0]) - crossfadeDuration) + "[outv] " +
                 "-map \"[outv]\" -an " + // -an removes audio - music videos use separate audio track
                 resultingFile;
             logger.info(performFFMPEG(crossfadeCommand));
@@ -219,18 +219,18 @@ public class FFmpegFunctions {
             for (int i = 0; i < snippets.length - 1; i++) {
                 double offset = getTotalDuration(snippets[i]) - crossfadeDuration;
                 if (i == 0) {
-                    filterComplex.append(String.format("[0:v][1:v]xfade=transition=fade:duration=%.3f:offset=%.3f[v01];", crossfadeDuration, offset));
+                    filterComplex.append(String.format("[0:v][1:v]xfade=transition=fade:duration=%.3f:offset=%.3f[v01]", crossfadeDuration, offset));
                 } else if (i == snippets.length - 2) {
-                    filterComplex.append(String.format("[v0%d][%d:v]xfade=transition=fade:duration=%.3f:offset=%.3f[outv];", i, i + 1, crossfadeDuration, offset));
+                    filterComplex.append(String.format(";[v0%d][%d:v]xfade=transition=fade:duration=%.3f:offset=%.3f[outv]", i, i + 1, crossfadeDuration, offset));
                 } else {
-                    filterComplex.append(String.format("[v0%d][%d:v]xfade=transition=fade:duration=%.3f:offset=%.3f[v0%d];", i, i + 1, crossfadeDuration, offset, i + 1));
+                    filterComplex.append(String.format(";[v0%d][%d:v]xfade=transition=fade:duration=%.3f:offset=%.3f[v0%d]", i, i + 1, crossfadeDuration, offset, i + 1));
                 }
             }
             
             // MUSIC VIDEOS: Video-only crossfade - audio comes from separate source
             // (Audio crossfade implementation preserved in AUDIO_CROSSFADE_IMPLEMENTATION.md)
             
-            String command = inputs + " -filter_complex \"" + filterComplex + "\" -map \"[outv]\" -an " + resultingFile;
+            String command = inputs + " -filter_complex " + filterComplex + " -map \"[outv]\" -an " + resultingFile;
             logger.info(performFFMPEG(command));
         }
         


### PR DESCRIPTION
- Remove outer quotes from filter_complex parameters
- Remove trailing semicolons from filter chains
- Fixes 100% failure rate on FFmpeg 6.1+ and 7.1+
- Affects concatVideoSnippetsWithCrossfade method

Resolves filter parsing errors:
- '[AVFilterGraph] Trailing garbage after a filter'
- 'Failed to set value for option filter_complex: Invalid argument'