### PR TITLE
Fix Java version consistency across all GitHub Actions workflows

### DIFF
--- a/.github/workflows/auto_release.yml
+++ b/.github/workflows/auto_release.yml
@@ -6,7 +6,7 @@ on:
     branches: [master]
 
 env:
-  JAVA_VERSION: '17'
+  JAVA_VERSION: '21'
 
 jobs:
   auto_release:

--- a/.github/workflows/manual_release.yml
+++ b/.github/workflows/manual_release.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'corretto'
           cache: 'maven'
       - name: Publish package

--- a/.github/workflows/pr_deployment.yml
+++ b/.github/workflows/pr_deployment.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
         with:
-          java-version: 17
+          java-version: 21
           distribution: 'corretto'
       - name: Building the app
         run: mvn --batch-mode --file pom.xml --update-snapshots package -P ex-integration
@@ -38,7 +38,7 @@ jobs:
       - name: Set up corretto JDK 17
         uses: actions/setup-java@v4
         with:
-          java-version: 17
+          java-version: 21
           distribution: 'corretto'
       - name: Create GitHub Release
         uses: actions/create-release@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ on:
         type: string
 
 env:
-  JAVA_VERSION: '17'
+  JAVA_VERSION: '21'
 
 jobs:
   release:


### PR DESCRIPTION
- Update release.yml: Java 17 → 21
- Update auto_release.yml: Java 17 → 21
- Update manual_release.yml: Java 17 → 21
- Update pr_deployment.yml: Java 17 → 21 (both instances)
- Ensures all workflows use Java 21 matching project configuration